### PR TITLE
Don't log when speed testing EmptyClient

### DIFF
--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -194,7 +194,7 @@ func (oc *optimizingClient) testSpeed() {
 					cancel()
 					break LOOP
 				}
-				if rr.err != nil {
+				if rr.err != nil && !errors.Is(rr.err, drand.ErrEmptyClientUnsupportedGet) {
 					oc.log.Infow("", "optimizing_client", "endpoint down when speed tested", "client", fmt.Sprintf("%s", rr.client), "err", rr.err)
 				}
 				stats = append(stats, rr.stat)

--- a/client/optimizing_test.go
+++ b/client/optimizing_test.go
@@ -82,7 +82,6 @@ func TestOptimizingGet(t *testing.T) {
 
 	waitForSpeedTest(t, oc, 10*time.Second)
 
-	oc.Get(context.Background(), 0)
 	// speed test will consume round 0 and 5 from c0 and c1
 	// then c1 will be used because it's faster
 	expectRound(t, latestResult(t, oc), 6) // round 6 from c1 and round 1 from c0 (discarded)


### PR DESCRIPTION
Fixes: https://github.com/drand/go-clients/issues/10